### PR TITLE
Use 'escapeValue' to escape the new line character

### DIFF
--- a/src/Eluceo/iCal/Property/Event/Description.php
+++ b/src/Eluceo/iCal/Property/Event/Description.php
@@ -34,7 +34,7 @@ class Description implements ValueInterface
      */
     public function getEscapedValue()
     {
-        return PropertyValueUtil::escapeValueAllowNewLine((string) $this->value);
+        return PropertyValueUtil::escapeValue((string) $this->value);
     }
 
     /**


### PR DESCRIPTION
We need to escape the new line character as well as per RFC : http://tools.ietf.org/html/rfc5545#section-3.3.11
